### PR TITLE
RxType updates, CPPM Enable, Translations

### DIFF
--- a/src/uniSet/lang.lua
+++ b/src/uniSet/lang.lua
@@ -9,7 +9,7 @@ local txt_Fields = {
 {"CH1-8 / CH9-16",				"CH1-8 / CH9-16"			}, -- 1
 {"dummy SBUS-ch8",				"dummy SBUS-ch8"			}, -- 2
 {"Servo am SBUS",				"Servo on SBUS"				}, -- 3
-{"dummy D8 only",				"dummy D8 only"				}, -- 4
+{"Ermoglichen CPPM",			"Enable CPPM"				}, -- 4
 {"Feinabgleich: Offset", 		"Tuning offset"				}, -- 5
 {"Abgleich Mittenfrequenz",		"Tuning enabled"			}, -- 6
 {"Servo Framerate", 			"Rate"						}, -- 7
@@ -30,7 +30,9 @@ local txt_Fields = {
 {"Rx Typ", 						"Rx Type"					}, --22
 {"Antenne0 (Anzahl)", 			"Antenna count[0]"			}, --23
 {"Antenne1 (Anzahl)", 			"Antenna count[1]"			}, --24
-{"Rx Reset",					"Rx Reset"					}  --25
+{"Rx Reset",					"Rx Reset"					}, --25
+{"Seite",						"Page"						}, --26
+{"Warten auf Rx",				"Waiting for Rx"			}  --27
 }
 
 


### PR DESCRIPTION
@strgaltdel 

I've added and updated RxType model names that are currently used in the OTX scripts.

Added "Enable CPPM" option to  Page <- 2 ->
but have not been able to make it only available for RxType {"X4R/X4R-SB", 3} ? Need help here

Reversed 9mS and 18mS as these were incorrect. (checked again - your remark at end of line states "servo pulse period 1=9ms")
I don't believe anyone can achieve 9mS using this script. After you turn 9mS to on, all channels are 18mS by default and there is no setting in the ETHOS script to change them individually to the 9mS rate. Need help here also

Changed current code to add "Seite" and "Page" into the lang.lua

Rich